### PR TITLE
Tx stream emits signatures along with transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## [0.0.7] - 2024-03-11
+### Changed
+- Tx stream emits signatures along with transactions (#1234).
+
+<!-- Item Template -->
+<!-- ## [0.0.0] - 2024-03-10
+### Added
+- Added support for XYZ feature (#1234).
+### Changed
+- Improved performance of ABC calculation.
+### Fixed
+- Fixed bug causing application crash under certain conditions (#5678). -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [0.0.7] - 2024-03-11
 ### Changed
-- Tx stream emits signatures along with transactions (#1234).
+- Tx stream emits signatures along with transactions (#4).
 
 <!-- Item Template -->
 <!-- ## [0.0.0] - 2024-03-10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 description = "A Rust library for seamless integration with Merkle's services."
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 rust-version = "1.65"
 repository = "https://github.com/merkle3/merkle-sdk-rs"
@@ -20,4 +20,4 @@ tokio-stream = "0.1.14"
 tokio-tungstenite = { version = "0.20.1", features = ["native-tls"] }
 
 # workspace crates
-merkle-sdk-transactions = { version = "0.0.6", path = "transactions" }
+merkle-sdk-transactions = { version = "0.0.7", path = "transactions" }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following to your cargo.toml file:
 
 ```toml
 [dependencies]
-merkle-sdk = "0.0.6"
+merkle-sdk = "0.0.7"
 ```
 
 ## Examples

--- a/transactions/src/builder.rs
+++ b/transactions/src/builder.rs
@@ -55,7 +55,7 @@ impl ConnectionBuilder {
     /// Sets the connection's base url. This is generally not required
     /// but we leave this setting open to increase flexibility.
     /// Example:
-    /// 
+    ///
     /// ```rust
     ///
     /// use merkle_sdk_transactions::Connection;
@@ -77,7 +77,6 @@ impl ConnectionBuilder {
         self
     }
 
-    
     pub fn mainnet(mut self) -> Self {
         self.chain = ChainName::Mainnet.as_u64();
         self

--- a/transactions/src/lib.rs
+++ b/transactions/src/lib.rs
@@ -1,4 +1,23 @@
 mod builder;
 mod stream;
 pub use builder::{ChainId, ChainName, ConnectionBuilder};
+use ethers::types::{transaction::eip2718::TypedTransaction, Bytes, Signature};
 pub use stream::{Connection, Transactions, TxnStreamError};
+
+/// Wrapper struct for a `ethers-rs` transaction plus signature.
+#[derive(Debug)]
+pub struct Transaction {
+    /// The inner transaction.
+    pub inner: TypedTransaction,
+    /// Inner transaction signature.
+    pub signature: Signature,
+}
+
+impl Transaction {
+    /// Returns the RLP bytes representation of the transaction.
+    /// These [`Bytes`] represent a signed transaction that can be
+    /// relayed to the network.
+    pub fn rlp_signed(&self) -> Bytes {
+        self.inner.rlp_signed(&self.signature)
+    }
+}


### PR DESCRIPTION
### Requirement
Some users requested the ability to add a signature field to items yielded by our transaction stream. The primary goal is to allow users to:

Receive a pending transaction from our stream along with signature fields.
Sign the transaction, thereby appending a signature field to the transaction data.
Relay the signed transaction back into the network for further processing or verification.